### PR TITLE
feat(disable-channel): 添加通道关键词匹配就绪状态检查(#530)

### DIFF
--- a/common/disable-channel.go
+++ b/common/disable-channel.go
@@ -10,6 +10,7 @@ import (
 
 type DisableChannelKeyword struct {
 	AcMachines *goahocorasick.Machine
+	ready      bool
 	mutex      sync.RWMutex
 }
 
@@ -59,6 +60,7 @@ func (d *DisableChannelKeyword) Load(keywords string) {
 		machine := new(goahocorasick.Machine)
 		if err := machine.Build(patterns); err == nil {
 			d.AcMachines = machine
+			d.ready = true
 		} else {
 			logger.SysError("failed to build Aho-Corasick machine: " + err.Error())
 		}
@@ -66,6 +68,10 @@ func (d *DisableChannelKeyword) Load(keywords string) {
 }
 
 func (d *DisableChannelKeyword) IsContains(message string) bool {
+	if !d.ready {
+		return false
+	}
+
 	d.mutex.RLock()
 	defer d.mutex.RUnlock()
 


### PR DESCRIPTION
- 在 DisableChannelKeyword 结构体中新增 ready 字段
- 在 Load 方法中设置 ready 状态，确保 Aho-Corasick 机器成功构建
- 在 IsContains 方法中增加就绪状态检查，防止未初始化时进行匹配

[//]: # "请按照以下格式关联 issue"
[//]: # "请在提交 PR 前确认所提交的功能可用，附上截图即可，这将有助于项目维护者 review & merge 该 PR，谢谢"
[//]: # "项目维护者一般仅在周末处理 PR，因此如若未能及时回复希望能理解"
[//]: # "请在提交 PR 之前删除上面的注释"

close #issue_number

我已确认该 PR 已自测通过，相关截图如下：
